### PR TITLE
fix: abort on build errors during release workflow runs

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,7 @@
-# Build the main
+#!/bin/bash
+set -exuo pipefail
+
+# Build the source distribution tarball
 uv build --sdist
 
 # Build the wheels


### PR DESCRIPTION
Currently, the `build.sh` script used in the release workflow does not exit early on build errors, and it will only return the exit code of the final `uv build` command. E.g. if the windows wheel fails to build, the script will continue to run until completion, and if the final linux wheel build succeeds, then the script will return a `0` exit code. This can result in PyPI releases that are missing wheels.

This patch:
- adds `set -e` to the build script so that it will exit immediately on errors and return a non-zero exit code
- adds `set -x` to the build script for better debug output since it is only used internally
- adds `set -u` and `set -o pipefail` to the build script for future-proofing / to satisfy my pedantry
- adds a missing bash shebang to the build script